### PR TITLE
fix: params.permit support array params

### DIFF
--- a/lib/strong_parameters.js
+++ b/lib/strong_parameters.js
@@ -9,6 +9,8 @@
  *
  * ```js
  * const params = ctx.params.permit('title', 'body');
+ * const params = ctx.params.permit(['title', 'body']);
+ * const params = ctx.params.permit(['title', 'body'], 'key1', 'key2');
  * ```
  *
  * @param {Array} keys params keys list
@@ -18,7 +20,14 @@ module.exports = function permit(...keys) {
   const orginal = this;
   const params = {};
   for (const k of keys) {
-    params[k] = orginal[k];
+    // permit([k1, k2, ...])
+    if (Array.isArray(k)) {
+      for (const subKey of k) {
+        params[subKey] = orginal[subKey];
+      }
+    } else {
+      params[k] = orginal[k];
+    }
   }
   params.isPermitted = () => true;
   return params;

--- a/test/fixtures/apps/dummy/app/controller/keys.js
+++ b/test/fixtures/apps/dummy/app/controller/keys.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async ctx => {
+  const helloParam = ctx.params.permit(['name', 'age', 'location'], 'gogo', 'other');
+  ctx.set('permitted', helloParam.isPermitted());
+  ctx.body = helloParam;
+}

--- a/test/fixtures/apps/dummy/app/router.js
+++ b/test/fixtures/apps/dummy/app/router.js
@@ -2,4 +2,5 @@
 
 module.exports = app => {
   app.all('/hello/:name', app.controller.hello);
+  app.all('/keys/:name', app.controller.keys);
 };

--- a/test/parameters.test.js
+++ b/test/parameters.test.js
@@ -24,6 +24,15 @@ describe('test/parameters.test.js', () => {
       assert.deepStrictEqual({ name: 'huacnlee', age: '1' }, res.body);
     });
 
+    it('should work with multi keys', async () => {
+      const res = await app.httpRequest()
+        .get('/keys/huacnlee?age=1&bad_key=foo&name=123123&gogo=11');
+      assert.equal(200, res.status);
+      assert.equal('true', res.headers.permitted);
+      assert.equal(null, res.body.bad_key);
+      assert.deepStrictEqual({ name: 'huacnlee', age: '1', gogo: '11' }, res.body);
+    });
+
     it('should work for post body', async () => {
       app.mockLog();
       const res = await app.httpRequest()


### PR DESCRIPTION
```js
ctx.params.permit(['name', 'age', 'location'], 'gogo', 'other');
```